### PR TITLE
Add gulp watch script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.1.3",
   "description": "",
   "main": "js/scripts.js",
+  "scripts": {
+    "watch": "gulp watch"
+  },
   "keywords": [
     "portfolio",
     "personal",
     "website",
-	"tech",
-	"coding",
+    "tech",
+    "coding",
     "dev"
   ],
   "author": "Ryan Fitzgerald",


### PR DESCRIPTION
Makes it so that people who don't have gulp installed globally (like me) can run `npm run watch` instead of having to find the gulp executable in `node_modules`.